### PR TITLE
Request projectinfo in bulk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-	implementation "org.moddingx:CurseWrapper:2.0"
+	implementation "org.moddingx:CurseWrapper:2.1"
 
 	implementation 'com.atlassian.commonmark:commonmark:0.17.0'
 	implementation "net.sf.jopt-simple:jopt-simple:6.0-alpha-3"


### PR DESCRIPTION
Requests the projects in bulk instead of one-by-one as described in. #11

The file information is still called once for each project, but the runtime has been cut down from 5-10 minutes to 8 seconds.

I have also included a progressbar in the output, not being able to see the progress is what inspired me to make https://github.com/EnigmaticaModpacks/Enigmatica6/pull/5013 several days ago (never had run your modlist creator myself for that modpack and i had no idea how long it could take without any sort of indicator as to its progress), hence hoping it makes it into the original:


<img width="453" alt="Screen Shot 2022-06-18 at 16 46 12" src="https://user-images.githubusercontent.com/3179271/174443756-e31d6e0f-4482-4a84-bb82-dcdd9d447672.png">

ps, as is evident by this pull request my java skills are not that advanced, so there is probably room for some cleanup. ^-^
